### PR TITLE
Docker: clean up slice after package installation.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,8 @@ RUN yum install --assumeyes \
     rubygems \
     gettext-devel \
     flex \
-    vim
+    vim \
+    && yum clean all
 
 RUN yum upgrade --assumeyes && yum clean all
 


### PR DESCRIPTION
To keep each slice minimal we should clean up all leftovers.

Signed-off-by: Mattias Ryrlén <mattiasr@op5.com>